### PR TITLE
Replace deprecated selectors

### DIFF
--- a/styles/crystal-block.less
+++ b/styles/crystal-block.less
@@ -4,12 +4,12 @@
 // for a full listing of what's available.
 @import "ui-variables";
 
-:host, atom-text-editor, atom-text-editor::shadow {
+:host, atom-text-editor, atom-text-editor.editor {
   .line-number.crystal-block-highlight {
     color: #fff;
     background-color: @background-color-highlight;
   }
-  
+
   .highlights {
     .crystal-block-highlight .region {
       background-color: @background-color-highlight;


### PR DESCRIPTION
# Why ?
Atom is evolving, and remove the ::shadow selector from atom-text-editor. Instead, it's becoming atom-text-editor.editor. Just as indicates Atom, and reported in #1, this PR replaces the selector to remove deprecation calls.